### PR TITLE
Fix UrlBuilder hash

### DIFF
--- a/src/Bigbluebutton.php
+++ b/src/Bigbluebutton.php
@@ -21,7 +21,7 @@ class Bigbluebutton extends BigBlueButtonParent
     {
         $this->bbbServerBaseUrl = Str::finish(trim($bbbServerBaseUrl), '/');
         $this->securitySecret = trim($securitySecret);
-        $this->urlBuilder = new UrlBuilder($this->securitySecret, $this->bbbServerBaseUrl);
+        $this->urlBuilder = new UrlBuilder($this->securitySecret, $this->bbbServerBaseUrl, 'sha1');
         $this->transport = $transport ?? CurlTransport::createWithDefaultOptions();
     }
 }


### PR DESCRIPTION
Based on this [commit](https://github.com/littleredbutton/bigbluebutton-api-php/commit/b55171bb165d5cf739ab3dd3c8dfa6c3928e4819), We need to add hash for UrlBuilder